### PR TITLE
feature: friendly names for prometheus wireguard exporter

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -232,8 +232,9 @@ PreDown = {{ .Server.PreDown }}
 PostDown = {{ .Server.PostDown }}
 {{- range .Clients }}
 {{ if .Enable -}}
-# {{.Name}} / {{.Email}} / Updated: {{.Updated}} / Created: {{.Created}}
 [Peer]
+# {{.Email}} / Updated: {{.Updated}} / Created: {{.Created}}
+# {{.Name}}
 PublicKey = {{ .PublicKey }}
 PresharedKey = {{ .PresharedKey }}
 AllowedIPs = {{ StringsJoin .Address ", " }}


### PR DESCRIPTION
[Mindflavor Prometheus Wireguard Exporter](https://mindflavor.github.io/prometheus_wireguard_exporter/) allows for friendly names. But the name [must be a comment below the [Peer] defintion](https://github.com/MindFlavor/prometheus_wireguard_exporter#friendly-names). 
It only take

This commit move the corresponding line below the [Peer] definition in the template.
The friendly name must be the last comment in the section